### PR TITLE
Expand store interface with node-type operations and tree queries

### DIFF
--- a/store.go
+++ b/store.go
@@ -1,6 +1,8 @@
 package forest
 
 import (
+	"fmt"
+
 	"git.sr.ht/~whereswaldon/forest-go/fields"
 )
 
@@ -8,15 +10,26 @@ type Store interface {
 	Size() (int, error)
 	CopyInto(Store) error
 	Get(*fields.QualifiedHash) (Node, bool, error)
+	GetIdentity(*fields.QualifiedHash) (Node, bool, error)
+	GetCommunity(*fields.QualifiedHash) (Node, bool, error)
+	GetConversation(communityID, conversationID *fields.QualifiedHash) (Node, bool, error)
+	GetReply(communityID, conversationID, replyID *fields.QualifiedHash) (Node, bool, error)
+	Children(*fields.QualifiedHash) ([]*fields.QualifiedHash, error)
 	Add(Node) error
 }
 
 type MemoryStore struct {
-	Items map[string]Node
+	Items    map[string]Node
+	ChildMap map[string][]string
 }
 
+var _ Store = &MemoryStore{}
+
 func NewMemoryStore() *MemoryStore {
-	return &MemoryStore{make(map[string]Node)}
+	return &MemoryStore{
+		Items:    make(map[string]Node),
+		ChildMap: make(map[string][]string),
+	}
 }
 
 func (m *MemoryStore) Size() (int, error) {
@@ -40,9 +53,44 @@ func (m *MemoryStore) Get(id *fields.QualifiedHash) (Node, bool, error) {
 	return m.GetID(idString)
 }
 
+func (m *MemoryStore) GetIdentity(id *fields.QualifiedHash) (Node, bool, error) {
+	return m.Get(id)
+}
+
+func (m *MemoryStore) GetCommunity(id *fields.QualifiedHash) (Node, bool, error) {
+	return m.Get(id)
+}
+
+func (m *MemoryStore) GetConversation(communityID, conversationID *fields.QualifiedHash) (Node, bool, error) {
+	return m.Get(conversationID)
+}
+
+func (m *MemoryStore) GetReply(communityID, conversationID, replyID *fields.QualifiedHash) (Node, bool, error) {
+	return m.Get(replyID)
+}
+
 func (m *MemoryStore) GetID(id string) (Node, bool, error) {
 	item, has := m.Items[id]
 	return item, has, nil
+}
+
+func (m *MemoryStore) Children(id *fields.QualifiedHash) ([]*fields.QualifiedHash, error) {
+	idString, err := id.MarshalString()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal node id into key: %w", err)
+	}
+	children, any := m.ChildMap[idString]
+	if !any {
+		return []*fields.QualifiedHash{}, nil
+	}
+	childIDs := make([]*fields.QualifiedHash, len(children))
+	for i, childStr := range children {
+		childIDs[i] = &fields.QualifiedHash{}
+		if err := childIDs[i].UnmarshalText([]byte(childStr)); err != nil {
+			return nil, fmt.Errorf("failed to transform key back into node id: %w", err)
+		}
+	}
+	return childIDs, nil
 }
 
 func (m *MemoryStore) Add(node Node) error {
@@ -59,6 +107,11 @@ func (m *MemoryStore) AddID(id string, node Node) error {
 		return nil
 	}
 	m.Items[id] = node
+	parentID, err := node.ParentID().MarshalString()
+	if err != nil {
+		return fmt.Errorf("failed to marshal string of parent node: %w", err)
+	}
+	m.ChildMap[parentID] = append(m.ChildMap[parentID], id)
 	return nil
 }
 
@@ -70,6 +123,8 @@ func (m *MemoryStore) AddID(id string, node Node) error {
 type CacheStore struct {
 	Cache, Back Store
 }
+
+var _ Store = &CacheStore{}
 
 // NewCacheStore creates a single logical store from the given two stores.
 // All items from `cache` are automatically copied into `base` during

--- a/store_test.go
+++ b/store_test.go
@@ -3,7 +3,8 @@ package forest_test
 import (
 	"testing"
 
-	"git.sr.ht/~whereswaldon/forest-go"
+	forest "git.sr.ht/~whereswaldon/forest-go"
+	"git.sr.ht/~whereswaldon/forest-go/fields"
 )
 
 func TestMemoryStore(t *testing.T) {
@@ -17,17 +18,37 @@ func testStandardStoreInterface(t *testing.T, s forest.Store, storeImplName stri
 	} else if err != nil {
 		t.Errorf("Expected new %s Size() to succeed, failed with %s", storeImplName, err)
 	}
-	id, _, com, rep := MakeReplyOrSkip(t)
-	nodes := []forest.Node{id, com, rep}
+	// create three test nodes, one of each type
+	identity, _, community, reply := MakeReplyOrSkip(t)
+	nodes := []forest.Node{identity, community, reply}
+
+	// create a set of functions that perform different "Get" operations on nodes
+	getFuncs := map[string]func(*fields.QualifiedHash) (forest.Node, bool, error){
+		"get":       s.Get,
+		"identity":  s.GetIdentity,
+		"community": s.GetCommunity,
+		"conversation": func(id *fields.QualifiedHash) (forest.Node, bool, error) {
+			return s.GetConversation(community.ID(), id)
+		},
+		"reply": func(id *fields.QualifiedHash) (forest.Node, bool, error) {
+			return s.GetReply(community.ID(), reply.ID(), id)
+		},
+	}
+
+	// ensure no getter functions succeed on an empty store
 	for _, i := range nodes {
-		if node, has, err := s.Get(i.ID()); has {
-			t.Errorf("Empty %s should not contain element %v", storeImplName, i.ID())
-		} else if err != nil {
-			t.Errorf("Empty %s Get() should not err with %s", storeImplName, err)
-		} else if node != nil {
-			t.Errorf("Empty %s Get() should return none-nil node %v", storeImplName, node)
+		for _, get := range getFuncs {
+			if node, has, err := get(i.ID()); has {
+				t.Errorf("Empty %s should not contain element %v", storeImplName, i.ID())
+			} else if err != nil {
+				t.Errorf("Empty %s Get() should not err with %s", storeImplName, err)
+			} else if node != nil {
+				t.Errorf("Empty %s Get() should return none-nil node %v", storeImplName, node)
+			}
 		}
 	}
+
+	// add each node
 	for count, i := range nodes {
 		if err := s.Add(i); err != nil {
 			t.Errorf("%s Add() should not err on Add(): %s", storeImplName, err)
@@ -37,14 +58,63 @@ func testStandardStoreInterface(t *testing.T, s forest.Store, storeImplName stri
 		} else if size != count+1 {
 			t.Errorf("%s Size() should be %d after %d Add()s, got %d", storeImplName, count+1, count+1, size)
 		}
-		if node, has, err := s.Get(i.ID()); !has {
-			t.Errorf("%s should contain element %v", storeImplName, i.ID())
-		} else if err != nil {
-			t.Errorf("%s Has() should not err with %s", storeImplName, err)
-		} else if !i.Equals(node) {
-			t.Errorf("%s Get() should return a node equal to the one that was Add()ed. Got %v, expected %v", storeImplName, node, i)
+	}
+
+	// map each node to the getters that should be successful in fetching it
+	nodesToGetters := []struct {
+		forest.Node
+		funcs []string
+	}{
+		{identity, []string{"get", "identity"}},
+		{community, []string{"get", "community"}},
+		{reply, []string{"get", "conversation", "reply"}},
+	}
+
+	// ensure all getters work for each node
+	for _, getterConfig := range nodesToGetters {
+		currentNode := getterConfig.Node
+		for _, getterName := range getterConfig.funcs {
+			if node, has, err := getFuncs[getterName](currentNode.ID()); !has {
+				t.Errorf("%s should contain element %v", storeImplName, currentNode.ID())
+			} else if err != nil {
+				t.Errorf("%s Has() should not err with %s", storeImplName, err)
+			} else if !currentNode.Equals(node) {
+				t.Errorf("%s Get() should return a node equal to the one that was Add()ed. Got %v, expected %v", storeImplName, node, currentNode)
+			}
 		}
 	}
+
+    // map nodes to the children that they ought to have within the store
+	nodesToChildren := []struct {
+		forest.Node
+		children []*fields.QualifiedHash
+	}{
+		{identity, []*fields.QualifiedHash{}},
+		{community, []*fields.QualifiedHash{reply.ID()}},
+		{reply, []*fields.QualifiedHash{}},
+	}
+
+    // check each node has its proper children
+	for _, childConfig := range nodesToChildren {
+		if children, err := s.Children(childConfig.ID()); err != nil {
+			t.Errorf("%s should not error fetching children of %v", storeImplName, childConfig.ID())
+		} else {
+			for _, child := range childConfig.children {
+				if !containsID(children, child) {
+					t.Errorf("%s should have %v as a child of %v", storeImplName, child, childConfig.ID())
+				}
+			}
+		}
+	}
+}
+
+func containsID(ids []*fields.QualifiedHash, id *fields.QualifiedHash) bool {
+	for _, current := range ids {
+		if current.Equals(id) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCacheStore(t *testing.T) {


### PR DESCRIPTION
While working on the implementation of the first Sprout relay, we discovered that we needed to be able to look up nodes in a more granular way, as well as look up the children of a given node. These operations seem inherently useful to the `Store` interface, so this PR adds them and implements tests.