### PR TITLE
Community and identity newline checking

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -169,6 +169,11 @@ func NewIdentityQualified(signer Signer, name *fields.QualifiedContent, metadata
 	identity.Metadata = *metadata
 	identity.Created = fields.TimestampFrom(time.Now())
 
+	// Check no newline in name
+	if name.ContainsString("\n") {
+		return nil, fmt.Errorf("Newline in username is illegal")
+	}
+
 	// get public key
 	pubkey, err := signer.PublicKey()
 	if err != nil {
@@ -257,6 +262,11 @@ func (n *Builder) NewCommunityQualified(name *fields.QualifiedContent, metadata 
 		return nil, err
 	}
 	c.IDDesc = *idDesc
+
+	// Check no newline in name
+	if name.ContainsString("\n") {
+		return nil, fmt.Errorf("Newline in community name is illegal")
+	}
 
 	// we've defined all pre-signature fields, it's time to sign the data
 	signedDataBytes, err := c.MarshalSignedData()

--- a/community_test.go
+++ b/community_test.go
@@ -16,6 +16,14 @@ func MakeCommunityOrSkip(t *testing.T) (*forest.Identity, forest.Signer, *forest
 	return identity, privkey, community
 }
 
+func TestCommunityNewline(t *testing.T) {
+	identity, privkey := MakeIdentityOrSkip(t)
+	_, err := forest.As(identity, privkey).NewCommunity("string with \n newline", "")
+	if err == nil {
+		t.Error("Failed to raise error in Community with newline in name")
+	}
+}
+
 func TestCommunityValidatesSelf(t *testing.T) {
 	identity, _, community := MakeCommunityOrSkip(t)
 	if correct, err := forest.ValidateID(community, *community.ID()); err != nil || !correct {

--- a/fields/primitives.go
+++ b/fields/primitives.go
@@ -140,6 +140,11 @@ func (v Blob) Contains(c []byte) bool {
     return strings.Contains(string(v), string(c))
 }
 
+// ContainsString checks if a substing exists in a Blob
+func (v Blob) ContainsString(s string) bool {
+    return v.Contains([]byte(s))
+}
+
 // MarshalBinary converts the Blob into its binary representation
 func (v Blob) MarshalBinary() ([]byte, error) {
 	return v, nil

--- a/fields/primitives.go
+++ b/fields/primitives.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/binary"
+	"strings"
 	"fmt"
 	"math"
 	"time"
@@ -133,6 +134,11 @@ func (t *TreeDepth) Equals(t2 *TreeDepth) bool {
 
 // Blob represents a quantity of arbitrary binary data in the Forest
 type Blob []byte
+
+// Contains checks if a substing of bytes exists in a Blob
+func (v Blob) Contains(c []byte) bool {
+    return strings.Contains(string(v), string(c))
+}
 
 // MarshalBinary converts the Blob into its binary representation
 func (v Blob) MarshalBinary() ([]byte, error) {

--- a/fields/primitives_test.go
+++ b/fields/primitives_test.go
@@ -44,10 +44,11 @@ func TestTextMarshalQualifiedHash(t *testing.T) {
 	if !q.Equals(out) {
 		t.Fatalf("Input and output do not match:\nin: %v\nout: %v", *q, *out)
 	}
+}
 
-	q.Blob = []byte(`this
-                    is a newline test`)
-	if !q.Blob.ContainsString("\n") {
+func TestBlobContains(t *testing.T) {
+     b := fields.Blob([]byte("something here"))
+     if !b.ContainsString("thing") {
         t.Fatal("ContainsString() failed to find newline in Blob.")
-	}
+     }
 }

--- a/fields/primitives_test.go
+++ b/fields/primitives_test.go
@@ -44,4 +44,10 @@ func TestTextMarshalQualifiedHash(t *testing.T) {
 	if !q.Equals(out) {
 		t.Fatalf("Input and output do not match:\nin: %v\nout: %v", *q, *out)
 	}
+
+	q.Blob = []byte(`this
+                    is a newline test`)
+	if !q.Blob.ContainsString("\n") {
+        t.Fatal("ContainsString() failed to find newline in Blob.")
+	}
 }

--- a/fields/qualifieds.go
+++ b/fields/qualifieds.go
@@ -15,8 +15,8 @@ const minSizeofQualified = sizeofDescriptor
 
 // concrete qualified data types
 type QualifiedHash struct {
-	Descriptor HashDescriptor `arbor:"order=0,recurse=serialize"`
-	Blob       Blob           `arbor:"order=1"`
+	Descriptor HashDescriptor      `arbor:"order=0,recurse=serialize"`
+	Blob                           `arbor:"order=1"`
 }
 
 const minSizeofQualifiedHash = sizeofHashDescriptor
@@ -98,8 +98,8 @@ func (q *QualifiedHash) Validate() error {
 }
 
 type QualifiedContent struct {
-	Descriptor ContentDescriptor `arbor:"order=0,recurse=serialize"`
-	Blob       Blob              `arbor:"order=1"`
+	Descriptor ContentDescriptor   `arbor:"order=0,recurse=serialize"`
+	Blob                           `arbor:"order=1"`
 }
 
 const minSizeofQualifiedContent = sizeofContentDescriptor
@@ -160,8 +160,8 @@ func (q *QualifiedContent) Validate() error {
 }
 
 type QualifiedKey struct {
-	Descriptor KeyDescriptor `arbor:"order=0,recurse=serialize"`
-	Blob       Blob          `arbor:"order=1"`
+	Descriptor KeyDescriptor       `arbor:"order=0,recurse=serialize"`
+	Blob                           `arbor:"order=1"`
 }
 
 const minSizeofQualifiedKey = sizeofKeyDescriptor
@@ -216,7 +216,7 @@ func (q *QualifiedKey) AsEntity() (*openpgp.Entity, error) {
 
 type QualifiedSignature struct {
 	Descriptor SignatureDescriptor `arbor:"order=0,recurse=serialize"`
-	Blob       Blob                `arbor:"order=1"`
+	Blob                           `arbor:"order=1"`
 }
 
 const minSizeofQualifiedSignature = sizeofSignatureDescriptor

--- a/identity_test.go
+++ b/identity_test.go
@@ -17,6 +17,14 @@ func MakeIdentityFromKeyOrSkip(t *testing.T, privKey, passphrase string) (*fores
 	return identity, signer
 }
 
+func TestIdentityNewline(t *testing.T) {
+	signer := testkeys.Signer(t, privKey1)
+	_, err := forest.NewIdentity(signer, "newline-in\nusername", "")
+	if err == nil {
+		t.Error("Failed to error with newline in username")
+	}
+}
+
 func MakeIdentityOrSkip(t *testing.T) (*forest.Identity, forest.Signer) {
 	return MakeIdentityFromKeyOrSkip(t, privKey1, testKeyPassphrase)
 }


### PR DESCRIPTION
Depends on [New method on Blobs: Contains()](https://github.com/arborchat/forest-go/pull/6)
Addresses [issue 1](https://github.com/arborchat/forest-go/issues/1)
Add community and identity newline checks in `builder.go`
Add newline checking tests to community_tests and identity_tests