### PR TITLE
Create tests and mock framework for grove type

### DIFF
--- a/grove/grove.go
+++ b/grove/grove.go
@@ -1,0 +1,72 @@
+/*
+Package grove implements an on-disk storage format for arbor forest
+nodes. This hierarchical storage format is called a "grove", and
+the management type implemented by this package satisfies the
+forest.Store interface.
+
+Note: this package is not yet complete.
+*/
+package grove
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FS represents a type that acts as a filesystem. It can create and
+// open files at specific paths
+type FS interface {
+	Open(path string) (*os.File, error)
+	Create(path string) (*os.File, error)
+	OpenFile(path string, flag int, perm os.FileMode) (*os.File, error)
+}
+
+// RelativeFS is a file system that acts relative to a specific path
+type RelativeFS struct {
+	Root string
+}
+
+// ensure RelativeFS satisfies the FS interface
+var _ FS = RelativeFS{}
+
+func (r RelativeFS) resolve(path string) string {
+	return filepath.Join(r.Root, path)
+}
+
+// Open opens the given path as an absolute path relative to the root
+// of the RelativeFS
+func (r RelativeFS) Open(path string) (*os.File, error) {
+	return os.Open(r.resolve(path))
+}
+
+// Create makes the given path as an absolute path relative to the root
+// of the RelativeFS
+func (r RelativeFS) Create(path string) (*os.File, error) {
+	return os.Create(r.resolve(path))
+}
+
+// OpenFile opens the given path as an absolute path relative to the root
+// of the RelativeFS
+func (r RelativeFS) OpenFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(r.resolve(path), flag, perm)
+}
+
+// Grove is an on-disk store for arbor forest nodes.
+type Grove struct {
+}
+
+// New constructs a Grove that stores nodes in a hierarchy rooted at
+// the given path.
+func New(root string) (*Grove, error) {
+	return NewWithFS(RelativeFS{root})
+}
+
+// NewWithFS constructs a Grove using the given FS implementation to
+// access its nodes. This is primarily useful for testing.
+func NewWithFS(fs FS) (*Grove, error) {
+	if fs == nil {
+		return nil, fmt.Errorf("fs cannot be nil")
+	}
+	return &Grove{}, nil
+}

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -1,0 +1,52 @@
+package grove_test
+
+import (
+	"os"
+	"testing"
+
+	"git.sr.ht/~whereswaldon/forest-go/grove"
+)
+
+type fakeFS struct {
+	files map[string]*os.File
+}
+
+var _ grove.FS = fakeFS{}
+
+// Open opens the given path as an absolute path relative to the root
+// of the fakeFS
+func (r fakeFS) Open(path string) (*os.File, error) {
+	return r.files[path], nil
+}
+
+// Create makes the given path as an absolute path relative to the root
+// of the fakeFS
+func (r fakeFS) Create(path string) (*os.File, error) {
+	return r.files[path], nil
+}
+
+// OpenFile opens the given path as an absolute path relative to the root
+// of the fakeFS
+func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return r.files[path], nil
+}
+
+func TestCreateEmptyGrove(t *testing.T) {
+	fs := fakeFS{
+		make(map[string]*os.File),
+	}
+	grove, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Fatalf("Failed to create grove with fake fs: %v", err)
+	}
+	if grove == nil {
+		t.Fatalf("Grove constructor did not err, but returned nil grove")
+	}
+}
+
+func TestCreateGroveFromNil(t *testing.T) {
+	_, err := grove.NewWithFS(nil)
+	if err == nil {
+		t.Fatalf("Created grove with nil fs, should have errored")
+	}
+}


### PR DESCRIPTION
The `Grove` type is the management type for on-disk node storage. This PR introduces the test scaffolding and initial tests for the type, but does not implement it fully. This type will ultimately implement `forest.Store`, but the implementation will come in subsequent PRs to reduce the review effort involved.

This type will be valuable for both the implementation of arbor relays and for clients managing their own nodes.