### PR TITLE
Implement the `Get` operation on Groves

### DIFF
--- a/grove/grove.go
+++ b/grove/grove.go
@@ -10,16 +10,28 @@ package grove
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+
+	"git.sr.ht/~whereswaldon/forest-go"
+	"git.sr.ht/~whereswaldon/forest-go/fields"
 )
+
+// File represents a type that supports file-like operations. *os.File
+// implements this interface, and will likely be used most of the time.
+// This interface exists mostly to simply testing.
+type File interface {
+	io.ReadWriteCloser
+	Name() string
+}
 
 // FS represents a type that acts as a filesystem. It can create and
 // open files at specific paths
 type FS interface {
-	Open(path string) (*os.File, error)
-	Create(path string) (*os.File, error)
-	OpenFile(path string, flag int, perm os.FileMode) (*os.File, error)
+	Open(path string) (File, error)
+	Create(path string) (File, error)
+	OpenFile(path string, flag int, perm os.FileMode) (File, error)
 }
 
 // RelativeFS is a file system that acts relative to a specific path
@@ -36,19 +48,19 @@ func (r RelativeFS) resolve(path string) string {
 
 // Open opens the given path as an absolute path relative to the root
 // of the RelativeFS
-func (r RelativeFS) Open(path string) (*os.File, error) {
+func (r RelativeFS) Open(path string) (File, error) {
 	return os.Open(r.resolve(path))
 }
 
 // Create makes the given path as an absolute path relative to the root
 // of the RelativeFS
-func (r RelativeFS) Create(path string) (*os.File, error) {
+func (r RelativeFS) Create(path string) (File, error) {
 	return os.Create(r.resolve(path))
 }
 
 // OpenFile opens the given path as an absolute path relative to the root
 // of the RelativeFS
-func (r RelativeFS) OpenFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+func (r RelativeFS) OpenFile(path string, flag int, perm os.FileMode) (File, error) {
 	return os.OpenFile(r.resolve(path), flag, perm)
 }
 
@@ -69,4 +81,11 @@ func NewWithFS(fs FS) (*Grove, error) {
 		return nil, fmt.Errorf("fs cannot be nil")
 	}
 	return &Grove{}, nil
+}
+
+// Get searches the grove for a node with the given id. It returns the node if it was
+// found, a boolean indicating whether it was found, and an error (if there was a
+// problem searching for the node).
+func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
+	return nil, false, nil
 }

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -97,10 +97,12 @@ func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
 		return nil, false, fmt.Errorf("failed determining file name for node: %w", err)
 	}
 	file, err := g.Open(filename)
+	// if the file doesn't exist, just return false with no error
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	// if it's some other error, wrap it and return
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, false, nil
-		}
 		return nil, false, fmt.Errorf("failed opening node file \"%s\": %w", filename, err)
 	}
 	b, err := ioutil.ReadAll(file)

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -1,40 +1,119 @@
 package grove_test
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
+	forest "git.sr.ht/~whereswaldon/forest-go"
 	"git.sr.ht/~whereswaldon/forest-go/grove"
+	"git.sr.ht/~whereswaldon/forest-go/testkeys"
 )
 
+// fakeFile implements the grove.File interface, but is entirely in-memory.
+// This helps speed testing.
+type fakeFile struct {
+	*bytes.Buffer
+	name string
+}
+
+var _ grove.File = &fakeFile{}
+
+func newFakeFile(name string, content []byte) *fakeFile {
+	return &fakeFile{
+		name:   name,
+		Buffer: bytes.NewBuffer(content),
+	}
+}
+
+func (f *fakeFile) Name() string {
+	return f.name
+}
+
+// needed to implement Close so that fakeFile is a io.ReadWriteCloser
+func (f *fakeFile) Close() error {
+	return nil
+}
+
+// fakeFS implements grove.FS, but is entirely in-memory.
 type fakeFS struct {
-	files map[string]*os.File
+	files map[string]*fakeFile
 }
 
 var _ grove.FS = fakeFS{}
 
 // Open opens the given path as an absolute path relative to the root
 // of the fakeFS
-func (r fakeFS) Open(path string) (*os.File, error) {
+func (r fakeFS) Open(path string) (grove.File, error) {
 	return r.files[path], nil
 }
 
 // Create makes the given path as an absolute path relative to the root
 // of the fakeFS
-func (r fakeFS) Create(path string) (*os.File, error) {
+func (r fakeFS) Create(path string) (grove.File, error) {
 	return r.files[path], nil
 }
 
 // OpenFile opens the given path as an absolute path relative to the root
 // of the fakeFS
-func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, error) {
 	return r.files[path], nil
 }
 
-func TestCreateEmptyGrove(t *testing.T) {
-	fs := fakeFS{
-		make(map[string]*os.File),
+func newFakeFS() fakeFS {
+	return fakeFS{
+		make(map[string]*fakeFile),
 	}
+}
+
+type testNodeBuilder struct {
+	*testing.T
+	*forest.Builder
+	*forest.Community
+}
+
+func NewNodeBuilder(t *testing.T) *testNodeBuilder {
+	signer := testkeys.Signer(t, testkeys.PrivKey1)
+	id, err := forest.NewIdentity(signer, "node-builder", "")
+	if err != nil {
+		t.Errorf("Failed to create identity: %v", err)
+		return nil
+	}
+	builder := forest.As(id, signer)
+	community, err := builder.NewCommunity("nodes-built-for-testing", "")
+	if err != nil {
+		t.Errorf("Failed to create community: %v", err)
+		return nil
+	}
+	return &testNodeBuilder{
+		T:         t,
+		Builder:   builder,
+		Community: community,
+	}
+}
+
+// newReplyFile creates a fakeFile that contains the binary data for a reply
+// node that is a direct child of the given community and constructed by the
+// given builder. It returns the reply node as a convenience for testing.
+func (tnb *testNodeBuilder) newReplyFile(content string) (*forest.Reply, *fakeFile) {
+	reply, err := tnb.NewReply(tnb.Community, content, "")
+	if err != nil {
+		tnb.T.Errorf("Failed generating test reply node: %v", err)
+	}
+	b, err := reply.MarshalBinary()
+	if err != nil {
+		tnb.T.Errorf("Failed marshalling test reply node: %v", err)
+	}
+	id := reply.ID()
+	nodeID, err := id.MarshalString()
+	if err != nil {
+		tnb.T.Errorf("Failed to marshal node id: %v", err)
+	}
+	return reply, newFakeFile(nodeID, b)
+}
+
+func TestCreateEmptyGrove(t *testing.T) {
+	fs := newFakeFS()
 	grove, err := grove.NewWithFS(fs)
 	if err != nil {
 		t.Fatalf("Failed to create grove with fake fs: %v", err)
@@ -48,5 +127,36 @@ func TestCreateGroveFromNil(t *testing.T) {
 	_, err := grove.NewWithFS(nil)
 	if err == nil {
 		t.Fatalf("Created grove with nil fs, should have errored")
+	}
+}
+
+func TestGroveGet(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	// no nodes in fs, make sure we get nothing
+	if node, present, err := g.Get(reply.ID()); err != nil {
+		t.Errorf("Failed looking for %v (not present): %v", reply.ID(), err)
+	} else if present {
+		t.Errorf("Grove indicated that a node was present when it was not added")
+	} else if node != nil {
+		t.Errorf("Grove returned a node when the requested node was not present")
+	}
+
+	// add node to fs, now should be discoverable
+	fs.files[replyFile.Name()] = replyFile
+
+	// no nodes in fs, make sure we get nothing
+	if node, present, err := g.Get(reply.ID()); err != nil {
+		t.Errorf("Failed looking for %v (present): %v", reply.ID(), err)
+	} else if !present {
+		t.Errorf("Grove indicated that a node was not present when it should have been")
+	} else if node == nil {
+		t.Errorf("Grove did not return a node when the requested node was present")
 	}
 }

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -45,19 +45,23 @@ var _ grove.FS = fakeFS{}
 // Open opens the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) Open(path string) (grove.File, error) {
-	return r.files[path], nil
+	file, exists := r.files[path]
+	if !exists {
+		return nil, os.ErrNotExist
+	}
+	return file, nil
 }
 
 // Create makes the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) Create(path string) (grove.File, error) {
-	return r.files[path], nil
+	return r.Open(path)
 }
 
 // OpenFile opens the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, error) {
-	return r.files[path], nil
+	return r.Open(path)
 }
 
 func newFakeFS() fakeFS {


### PR DESCRIPTION
This PR implements and tests using a `Grove` to fetch a node from disk. It contains a single positive test case, but doesn't have exhaustive tests for all possible error conditions.

As part of this PR, i changed the test suite to work with a `File` interface instead of the `*os.File` type. This allows testing using entirely in-memory implementations. Some tests using actual on-disk nodes would also be valuable, but such tests are slower to run. Much of the changeset in this PR is actually just the effects of creating that `File` type on a great many type signatures.