### PR TITLE
Implement tests for all of the error cases in the `Get` operation on Groves

### DIFF
--- a/fields/qualifieds.go
+++ b/fields/qualifieds.go
@@ -15,8 +15,8 @@ const minSizeofQualified = sizeofDescriptor
 
 // concrete qualified data types
 type QualifiedHash struct {
-	Descriptor HashDescriptor      `arbor:"order=0,recurse=serialize"`
-	Blob                           `arbor:"order=1"`
+	Descriptor HashDescriptor `arbor:"order=0,recurse=serialize"`
+	Blob       `arbor:"order=1"`
 }
 
 const minSizeofQualifiedHash = sizeofHashDescriptor
@@ -87,6 +87,12 @@ func (q *QualifiedHash) MarshalString() (string, error) {
 	return string(s), e
 }
 
+// String returns the output of MarshalString, but does not return an error.
+func (q *QualifiedHash) String() string {
+	s, _ := q.MarshalString()
+	return s
+}
+
 func (q *QualifiedHash) Validate() error {
 	if err := q.Descriptor.Validate(); err != nil {
 		return err
@@ -98,8 +104,8 @@ func (q *QualifiedHash) Validate() error {
 }
 
 type QualifiedContent struct {
-	Descriptor ContentDescriptor   `arbor:"order=0,recurse=serialize"`
-	Blob                           `arbor:"order=1"`
+	Descriptor ContentDescriptor `arbor:"order=0,recurse=serialize"`
+	Blob       `arbor:"order=1"`
 }
 
 const minSizeofQualifiedContent = sizeofContentDescriptor
@@ -160,8 +166,8 @@ func (q *QualifiedContent) Validate() error {
 }
 
 type QualifiedKey struct {
-	Descriptor KeyDescriptor       `arbor:"order=0,recurse=serialize"`
-	Blob                           `arbor:"order=1"`
+	Descriptor KeyDescriptor `arbor:"order=0,recurse=serialize"`
+	Blob       `arbor:"order=1"`
 }
 
 const minSizeofQualifiedKey = sizeofKeyDescriptor
@@ -216,7 +222,7 @@ func (q *QualifiedKey) AsEntity() (*openpgp.Entity, error) {
 
 type QualifiedSignature struct {
 	Descriptor SignatureDescriptor `arbor:"order=0,recurse=serialize"`
-	Blob                           `arbor:"order=1"`
+	Blob       `arbor:"order=1"`
 }
 
 const minSizeofQualifiedSignature = sizeofSignatureDescriptor

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -91,7 +91,10 @@ func NewWithFS(fs FS) (*Grove, error) {
 // Get searches the grove for a node with the given id. It returns the node if it was
 // found, a boolean indicating whether it was found, and an error (if there was a
 // problem searching for the node).
-func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
+// The returned `present` will never be true unless the returned `node` holds an
+// actual node struct. If the file holding a node exists on disk but was unable
+// to be opened, read, or parsed, `present` will still be false.
+func (g *Grove) Get(nodeID *fields.QualifiedHash) (node forest.Node, present bool, err error) {
 	filename := nodeID.String()
 	file, err := g.Open(filename)
 	// if the file doesn't exist, just return false with no error
@@ -106,7 +109,7 @@ func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
 	if err != nil {
 		return nil, false, fmt.Errorf("failed reading bytes from \"%s\": %w", filename, err)
 	}
-	node, err := forest.UnmarshalBinaryNode(b)
+	node, err = forest.UnmarshalBinaryNode(b)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed unmarshalling node from \"%s\": %w", filename, err)
 	}

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -92,10 +92,7 @@ func NewWithFS(fs FS) (*Grove, error) {
 // found, a boolean indicating whether it was found, and an error (if there was a
 // problem searching for the node).
 func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
-	filename, err := nodeID.MarshalString()
-	if err != nil {
-		return nil, false, fmt.Errorf("failed determining file name for node: %w", err)
-	}
+	filename := nodeID.String()
 	file, err := g.Open(filename)
 	// if the file doesn't exist, just return false with no error
 	if errors.Is(err, os.ErrNotExist) {

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -227,6 +227,33 @@ func TestGroveGetErrorReadingFile(t *testing.T) {
 	} else if present {
 		t.Errorf("Grove indicated that a node was present when it could not be read")
 	} else if node != nil {
-		t.Errorf("Grove did returned a node when the requested node was unreadable")
+		t.Errorf("Grove returned a node when the requested node was unreadable")
+	}
+}
+
+func TestGroveGetErrorUnmarshallingFile(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	replyFile.Reset()
+	_, err := replyFile.Write([]byte("this is not an arbor node"))
+	if err != nil {
+		t.Skipf("Unable to write test data into node file: %v", err)
+	}
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	// add node to fs, now should be discoverable
+	fs.files[replyFile.Name()] = replyFile
+
+	// no nodes in fs, make sure we get nothing
+	if node, present, err := g.Get(reply.ID()); err == nil {
+		t.Errorf("Expected error unmarshalling file to be propagated upward, got nil")
+	} else if present {
+		t.Errorf("Grove indicated that a node was present when it could not be unmarshalled")
+	} else if node != nil {
+		t.Errorf("Grove returned a node when the requested node was unparsable")
 	}
 }

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -35,9 +35,51 @@ func (f *fakeFile) Close() error {
 	return nil
 }
 
+// errFile implements the grove.File interface and wraps another grove.File.
+// If the errFile's error field is set to nil, it is a transparent wrapper
+// for the underlying File. If the field is set to a non-nil error value,
+// this will be returned from all operations that can return an error.
+type errFile struct {
+	error
+	wrappedFile grove.File
+}
+
+var _ grove.File = &errFile{}
+
+func NewErrFile(file grove.File) *errFile {
+	return &errFile{
+		wrappedFile: file,
+	}
+}
+
+func (e *errFile) Name() string {
+	return e.wrappedFile.Name()
+}
+
+func (e *errFile) Read(b []byte) (int, error) {
+	if e.error != nil {
+		return 0, e.error
+	}
+	return e.wrappedFile.Read(b)
+}
+
+func (e *errFile) Write(b []byte) (int, error) {
+	if e.error != nil {
+		return 0, e.error
+	}
+	return e.wrappedFile.Write(b)
+}
+
+func (e *errFile) Close() error {
+	if e.error != nil {
+		return e.error
+	}
+	return e.wrappedFile.Close()
+}
+
 // fakeFS implements grove.FS, but is entirely in-memory.
 type fakeFS struct {
-	files map[string]*fakeFile
+	files map[string]grove.File
 }
 
 var _ grove.FS = fakeFS{}
@@ -66,7 +108,7 @@ func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, e
 
 func newFakeFS() fakeFS {
 	return fakeFS{
-		make(map[string]*fakeFile),
+		make(map[string]grove.File),
 	}
 }
 
@@ -162,5 +204,29 @@ func TestGroveGet(t *testing.T) {
 		t.Errorf("Grove indicated that a node was not present when it should have been")
 	} else if node == nil {
 		t.Errorf("Grove did not return a node when the requested node was present")
+	}
+}
+
+func TestGroveGetErrorReadingFile(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	errReplyFile := NewErrFile(replyFile)
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	// add node to fs, now should be discoverable
+	fs.files[errReplyFile.Name()] = errReplyFile
+	errReplyFile.error = os.ErrClosed
+
+	// no nodes in fs, make sure we get nothing
+	if node, present, err := g.Get(reply.ID()); err == nil {
+		t.Errorf("Expected error reading file to be propagated upward, got nil")
+	} else if present {
+		t.Errorf("Grove indicated that a node was present when it could not be read")
+	} else if node != nil {
+		t.Errorf("Grove did returned a node when the requested node was unreadable")
 	}
 }


### PR DESCRIPTION
Getting a node from a grove is actually fraught with potential failures:

- the file may be unopenable (permissions, exclusively open already, file locking, etc...)
- the file may be unreadable (disk errors, other crazy problems)
- the file may not contain a node (corruption, deliberate sabotage)

All of these error cases are fairly possible, and needed to be handled. The last implementation of `Get` handled them, but there weren't tests to ensure that things work as expected. This PR changes that.