### PR TITLE
Implement specialized Get operations as wrappers

### DIFF
--- a/grove/grove.go
+++ b/grove/grove.go
@@ -115,3 +115,67 @@ func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
 	}
 	return node, true, nil
 }
+
+// GetIdentity returns an Identity node with the given ID (if it is present
+// in the grove). This operation may be faster than using Get, as the grove
+// may be able to do less search work when it knows the type of node you're
+// looking for in advance.
+//
+// BUG(whereswaldon): The current implementation may return nodes of the
+// wrong NodeType if they match the provided ID
+func (g *Grove) GetIdentity(id *fields.QualifiedHash) (forest.Node, bool, error) {
+	// this naiive implementation is not efficient, but works as a short-term
+	// thing.
+	//
+	// TODO: change the on-disk representation so that operations like this can
+	// be fast (store different node types in different directories, etc...)
+	return g.Get(id)
+}
+
+// GetCommunity returns an Community node with the given ID (if it is present
+// in the grove). This operation may be faster than using Get, as the grove
+// may be able to do less search work when it knows the type of node you're
+// looking for in advance.
+//
+// BUG(whereswaldon): The current implementation may return nodes of the
+// wrong NodeType if they match the provided ID
+func (g *Grove) GetCommunity(id *fields.QualifiedHash) (forest.Node, bool, error) {
+	// this naiive implementation is not efficient, but works as a short-term
+	// thing.
+	//
+	// TODO: change the on-disk representation so that operations like this can
+	// be fast (store different node types in different directories, etc...)
+	return g.Get(id)
+}
+
+// GetConversation returns an Conversation node with the given ID (if it is present
+// in the grove). This operation may be faster than using Get, as the grove
+// may be able to do less search work when it knows the type of node you're
+// looking for and its parent node in advance.
+//
+// BUG(whereswaldon): The current implementation may return nodes of the
+// wrong NodeType if they match the provided ID
+func (g *Grove) GetConversation(communityID, conversationID *fields.QualifiedHash) (forest.Node, bool, error) {
+	// this naiive implementation is not efficient, but works as a short-term
+	// thing.
+	//
+	// TODO: change the on-disk representation so that operations like this can
+	// be fast (store different node types in different directories, etc...)
+	return g.Get(conversationID)
+}
+
+// GetReply returns an Reply node with the given ID (if it is present
+// in the grove). This operation may be faster than using Get, as the grove
+// may be able to do less search work when it knows the type of node you're
+// looking for and its parent community and conversation node in advance.
+//
+// BUG(whereswaldon): The current implementation may return nodes of the
+// wrong NodeType if they match the provided ID
+func (g *Grove) GetReply(communityID, conversationID, replyID *fields.QualifiedHash) (forest.Node, bool, error) {
+	// this naiive implementation is not efficient, but works as a short-term
+	// thing.
+	//
+	// TODO: change the on-disk representation so that operations like this can
+	// be fast (store different node types in different directories, etc...)
+	return g.Get(replyID)
+}


### PR DESCRIPTION
All of the more specialized Get() functions can be (inefficiently)
implemented as calls to the generic Get() function. For speed of
getting a working prototype, this is what I propose that we should
do for now. In the future, the Grove filesystem layout should allow
us to make getting nodes of a specific type a very efficient operation.

I've marked all of the functions with a bug tag that results from
not checking the type of the returned nodes. It was either that or
write specialized checking code that would just be scrapped later
anyway. This also saves the up-front cost of writing tests for these
functions right now, since they have no unique behavior. Obviously
they will need tests when their implementations diverge from the
generic operation though.