### PR TITLE
Add stub implementation of CopyInto

### DIFF
--- a/grove/grove.go
+++ b/grove/grove.go
@@ -115,3 +115,14 @@ func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
 	}
 	return node, true, nil
 }
+
+// CopyInto copies all nodes from the store into the provided store.
+//
+// BUG(whereswaldon): this method is not yet implemented. It requires
+// more extensive file manipulation than other Grove methods (listing
+// directory contents) and has therefore been deprioritized in favor
+// of the functionality that can be implemented simply. However, it is
+// implementable, and should be done as soon as is feasible.
+func (g *Grove) CopyInto(other forest.Store) error {
+	return fmt.Errorf("method CopyInto() is not currently implemented on Grove")
+}


### PR DESCRIPTION
Doing this method right would involve extending the grove.File
interface so that we could list the contents of directories.
This is doable, and it is the long-term plan. However, getting
Grove to be usable is more important, and this method isn't
critical to most Grove use-cases.