### PR TITLE
Implement Add() method on Groves

### DIFF
--- a/grove/grove.go
+++ b/grove/grove.go
@@ -115,3 +115,24 @@ func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
 	}
 	return node, true, nil
 }
+
+// Add inserts the node into the grove.
+func (g *Grove) Add(node forest.Node) error {
+	data, err := node.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to serialize node: %w", err)
+	}
+
+	id, _ := node.ID().MarshalString()
+	nodeFile, err := g.Create(id)
+	if err != nil {
+		return fmt.Errorf("failed to create file for node %s: %w", id, err)
+	}
+	defer nodeFile.Close()
+
+	_, err = nodeFile.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write data to file for node %s: %w", id, err)
+	}
+	return nil
+}

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -117,6 +117,10 @@ func (g *Grove) Get(nodeID *fields.QualifiedHash) (forest.Node, bool, error) {
 }
 
 // Add inserts the node into the grove.
+//
+// BUG(whereswaldon): If the node is already present, this will overwrite it.
+// This is rather wasteful. It would be better to detect the existing file and
+// do nothing instead.
 func (g *Grove) Add(node forest.Node) error {
 	data, err := node.MarshalBinary()
 	if err != nil {

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -84,6 +84,12 @@ type fakeFS struct {
 
 var _ grove.FS = fakeFS{}
 
+func newFakeFS() fakeFS {
+	return fakeFS{
+		make(map[string]grove.File),
+	}
+}
+
 // Open opens the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) Open(path string) (grove.File, error) {
@@ -97,14 +103,9 @@ func (r fakeFS) Open(path string) (grove.File, error) {
 // Create makes the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) Create(path string) (grove.File, error) {
-	file, exists := r.files[path]
 	// mimic os.Create(), so creating a file that already exists truncates
 	// the current one
-	if exists {
-		file.Reset()
-		return file, nil
-	}
-	file = newFakeFile(path, []byte{})
+	file := newFakeFile(path, []byte{})
 	r.files[path] = file
 
 	return file, nil
@@ -116,10 +117,46 @@ func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, e
 	return r.Open(path)
 }
 
-func newFakeFS() fakeFS {
-	return fakeFS{
-		make(map[string]grove.File),
+// errFS is a testing type that wraps an ordinary FS with the ability to
+// return a specific error on any function call.
+type errFS struct {
+	fs grove.FS
+	error
+}
+
+var _ grove.FS = errFS{}
+
+func newErrFS(fs grove.FS) *errFS {
+	return &errFS{
+		fs: fs,
 	}
+}
+
+// Open opens the given path as an absolute path relative to the root
+// of the errFS
+func (r errFS) Open(path string) (grove.File, error) {
+	if r.error != nil {
+		return nil, r.error
+	}
+	return r.fs.Open(path)
+}
+
+// Create makes the given path as an absolute path relative to the root
+// of the errFS
+func (r errFS) Create(path string) (grove.File, error) {
+	if r.error != nil {
+		return nil, r.error
+	}
+	return r.fs.Create(path)
+}
+
+// OpenFile opens the given path as an absolute path relative to the root
+// of the errFS
+func (r errFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, error) {
+	if r.error != nil {
+		return nil, r.error
+	}
+	return r.fs.OpenFile(path, flag, perm)
 }
 
 type testNodeBuilder struct {

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -307,3 +307,19 @@ func TestGroveAddFailToWrite(t *testing.T) {
 		t.Errorf("Expected Add() to fail when writing to file fails")
 	}
 }
+
+func TestGroveAddFailToCreate(t *testing.T) {
+	fs := newFakeFS()
+	efs := newErrFS(fs)
+	efs.error = os.ErrPermission
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, _ := fakeNodeBuilder.newReplyFile("test content")
+	g, err := grove.NewWithFS(efs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	if err := g.Add(reply); err == nil {
+		t.Errorf("Expected Add() to fail when creating file fails")
+	}
+}

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -290,3 +290,20 @@ func TestGroveAdd(t *testing.T) {
 		t.Errorf("Expected Add() to succeed: %v", err)
 	}
 }
+
+func TestGroveAddFailToWrite(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	eFile := NewErrFile(replyFile)
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+	fs.files[eFile.Name()] = eFile
+	eFile.error = os.ErrClosed
+
+	if err := g.Add(reply); err == nil {
+		t.Errorf("Expected Add() to fail when writing to file fails")
+	}
+}


### PR DESCRIPTION
This PR makes it possible (finally) to insert nodes into a Grove. Testing all of the edge cases of adding a node required a lot of new test harness code.

I needed a node type that would fail serialization, for instance. The current nodes can't actually fail that operation unless someone modifies the struct definitions in an illegal way (a compile-time problem, not runtime), so I had to implement the `forest.Node` interface just so that one method could error.

Similarly, I had to expand the FS implementation so that `Create()` worked like `os.Create` and truncates the file if it already exists. This required adding a `Truncate()` method to the files. Since the `Grove` type doesn't actually need the Truncate method, it seemed best to not add it to `grove.File`, but instead to declare a private interface in the test package that required it.