### PR TITLE
Implement Children() and Recent() on Grove type

### DIFF
--- a/fields/primitives.go
+++ b/fields/primitives.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/binary"
-	"strings"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 )
 
@@ -137,12 +137,12 @@ type Blob []byte
 
 // Contains checks if a substing of bytes exists in a Blob
 func (v Blob) Contains(c []byte) bool {
-    return strings.Contains(string(v), string(c))
+	return strings.Contains(string(v), string(c))
 }
 
 // ContainsString checks if a substing exists in a Blob
 func (v Blob) ContainsString(s string) bool {
-    return v.Contains([]byte(s))
+	return v.Contains([]byte(s))
 }
 
 // MarshalBinary converts the Blob into its binary representation
@@ -274,7 +274,7 @@ var ValidNodeTypes = map[NodeType]struct{}{
 	NodeTypeReply:     struct{}{},
 }
 
-var nodeTypeNames = map[NodeType]string{
+var NodeTypeNames = map[NodeType]string{
 	NodeTypeIdentity:  "identity",
 	NodeTypeCommunity: "community",
 	NodeTypeReply:     "reply",
@@ -285,7 +285,7 @@ func (t NodeType) MarshalBinary() ([]byte, error) {
 }
 
 func (t NodeType) MarshalText() ([]byte, error) {
-	return []byte(nodeTypeNames[t]), nil
+	return []byte(NodeTypeNames[t]), nil
 }
 
 func (t *NodeType) UnmarshalBinary(b []byte) error {
@@ -321,7 +321,7 @@ var ValidHashTypes = map[HashType][]ContentLength{
 	HashTypeSHA512:   []ContentLength{HashDigestLengthSHA512_256},
 }
 
-var hashNames = map[HashType]string{
+var HashNames = map[HashType]string{
 	HashTypeNullHash: "NullHash",
 	HashTypeSHA512:   "SHA512",
 }
@@ -331,11 +331,11 @@ func (t HashType) MarshalBinary() ([]byte, error) {
 }
 
 func (t HashType) MarshalText() ([]byte, error) {
-	return []byte(hashNames[t]), nil
+	return []byte(HashNames[t]), nil
 }
 
 func (t *HashType) UnmarshalText(b []byte) error {
-	for hashType, hashName := range hashNames {
+	for hashType, hashName := range HashNames {
 		if hashName == string(b) {
 			*t = hashType
 			return nil
@@ -375,7 +375,7 @@ var ValidContentTypes = map[ContentType]struct{}{
 	ContentTypeJSON:       struct{}{},
 }
 
-var contentNames = map[ContentType]string{
+var ContentNames = map[ContentType]string{
 	ContentTypeUTF8String: "UTF-8",
 	ContentTypeJSON:       "JSON",
 }
@@ -385,7 +385,7 @@ func (t ContentType) MarshalBinary() ([]byte, error) {
 }
 
 func (t ContentType) MarshalText() ([]byte, error) {
-	return []byte(contentNames[t]), nil
+	return []byte(ContentNames[t]), nil
 }
 
 func (t *ContentType) UnmarshalBinary(b []byte) error {
@@ -419,7 +419,7 @@ var ValidKeyTypes = map[KeyType]struct{}{
 	KeyTypeOpenPGP: struct{}{},
 }
 
-var keyNames = map[KeyType]string{
+var KeyNames = map[KeyType]string{
 	KeyTypeNoKey:   "None",
 	KeyTypeOpenPGP: "OpenPGP",
 }
@@ -429,7 +429,7 @@ func (t KeyType) MarshalBinary() ([]byte, error) {
 }
 
 func (t KeyType) MarshalText() ([]byte, error) {
-	return []byte(keyNames[t]), nil
+	return []byte(KeyNames[t]), nil
 }
 
 func (t *KeyType) UnmarshalBinary(b []byte) error {
@@ -461,7 +461,7 @@ var ValidSignatureTypes = map[SignatureType]struct{}{
 	SignatureTypeOpenPGP: struct{}{},
 }
 
-var signatureNames = map[SignatureType]string{
+var SignatureNames = map[SignatureType]string{
 	SignatureTypeOpenPGP: "OpenPGP",
 }
 
@@ -470,7 +470,7 @@ func (t SignatureType) MarshalBinary() ([]byte, error) {
 }
 
 func (t SignatureType) MarshalText() ([]byte, error) {
-	return []byte(signatureNames[t]), nil
+	return []byte(SignatureNames[t]), nil
 }
 
 func (t *SignatureType) UnmarshalBinary(b []byte) error {

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -209,6 +209,7 @@ func (g *Grove) Children(id *fields.QualifiedHash) ([]*fields.QualifiedHash, err
 }
 
 // Recent returns a slice of the most recently-created nodes of the given type.
+// The slice is sorted so that the most-recently-created nodes are at the beginning.
 func (g *Grove) Recent(nodeType fields.NodeType, quantity int) ([]forest.Node, error) {
 	nodes, err := g.allNodes()
 	if err != nil {

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -233,7 +233,7 @@ func (g *Grove) Recent(nodeType fields.NodeType, quantity int) ([]forest.Node, e
 		case *forest.Reply:
 			b = n.CommonNode
 		}
-		return a.Created < b.Created
+		return a.Created > b.Created
 	})
 	rightType := make([]forest.Node, 0, quantity)
 	for _, node := range nodes {
@@ -252,5 +252,8 @@ func (g *Grove) Recent(nodeType fields.NodeType, quantity int) ([]forest.Node, e
 			}
 		}
 	}
-	return rightType[:quantity], nil
+	if len(rightType) > quantity {
+		rightType = rightType[:quantity]
+	}
+	return rightType, nil
 }

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -88,6 +88,12 @@ type fakeFS struct {
 
 var _ grove.FS = fakeFS{}
 
+func newFakeFS() fakeFS {
+	return fakeFS{
+		make(map[string]grove.File),
+	}
+}
+
 // Open opens the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) Open(path string) (grove.File, error) {
@@ -101,7 +107,12 @@ func (r fakeFS) Open(path string) (grove.File, error) {
 // Create makes the given path as an absolute path relative to the root
 // of the fakeFS
 func (r fakeFS) Create(path string) (grove.File, error) {
-	return r.Open(path)
+	// mimic os.Create(), so creating a file that already exists truncates
+	// the current one
+	file := newFakeFile(path, []byte{})
+	r.files[path] = file
+
+	return file, nil
 }
 
 // OpenFile opens the given path as an absolute path relative to the root
@@ -110,10 +121,46 @@ func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, e
 	return r.Open(path)
 }
 
-func newFakeFS() fakeFS {
-	return fakeFS{
-		make(map[string]grove.File),
+// errFS is a testing type that wraps an ordinary FS with the ability to
+// return a specific error on any function call.
+type errFS struct {
+	fs grove.FS
+	error
+}
+
+var _ grove.FS = errFS{}
+
+func newErrFS(fs grove.FS) *errFS {
+	return &errFS{
+		fs: fs,
 	}
+}
+
+// Open opens the given path as an absolute path relative to the root
+// of the errFS
+func (r errFS) Open(path string) (grove.File, error) {
+	if r.error != nil {
+		return nil, r.error
+	}
+	return r.fs.Open(path)
+}
+
+// Create makes the given path as an absolute path relative to the root
+// of the errFS
+func (r errFS) Create(path string) (grove.File, error) {
+	if r.error != nil {
+		return nil, r.error
+	}
+	return r.fs.Create(path)
+}
+
+// OpenFile opens the given path as an absolute path relative to the root
+// of the errFS
+func (r errFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, error) {
+	if r.error != nil {
+		return nil, r.error
+	}
+	return r.fs.OpenFile(path, flag, perm)
 }
 
 type testNodeBuilder struct {

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -81,6 +81,13 @@ func (e *errFile) Close() error {
 	return e.wrappedFile.Close()
 }
 
+func (e *errFile) Readdir(n int) ([]os.FileInfo, error) {
+	if e.error != nil {
+		return nil, e.error
+	}
+	return e.wrappedFile.Readdir(n)
+}
+
 // fakeFS implements grove.FS, but is entirely in-memory.
 type fakeFS struct {
 	files map[string]grove.File

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -420,3 +420,21 @@ func TestGroveChildren(t *testing.T) {
 		t.Errorf("Expected 3 child nodes for community, found none")
 	}
 }
+
+func TestGroveChildrenOpenRootFails(t *testing.T) {
+	fs := newFakeFS()
+	efs := newErrFS(fs)
+	efs.error = os.ErrPermission
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, _ := fakeNodeBuilder.newReplyFile("test content")
+	g, err := grove.NewWithFS(efs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	if children, err := g.Children(reply.ID()); err == nil {
+		t.Errorf("Expected error opening root grove dir to cause Children() to fail, but did not error")
+	} else if len(children) > 0 {
+		t.Errorf("Expected no child nodes to be returned when opening root grove dir fails, but found %d", len(children))
+	}
+}

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -438,3 +438,24 @@ func TestGroveChildrenOpenRootFails(t *testing.T) {
 		t.Errorf("Expected no child nodes to be returned when opening root grove dir fails, but found %d", len(children))
 	}
 }
+
+func TestGroveChildrenOpenNodeFails(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	eReplyFile := NewErrFile(replyFile)
+	eReplyFile.error = os.ErrPermission
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	// add node to fs, now should be discoverable
+	fs.files[eReplyFile.Name()] = eReplyFile
+
+	if children, err := g.Children(reply.ID()); err == nil {
+		t.Errorf("Expected permission error when reading node file to be propagated upward, but Children() did not error")
+	} else if len(children) > 0 {
+		t.Errorf("Expected no child nodes for when reading a node failed, found %d", len(children))
+	}
+}

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -459,3 +459,23 @@ func TestGroveChildrenOpenNodeFails(t *testing.T) {
 		t.Errorf("Expected no child nodes for when reading a node failed, found %d", len(children))
 	}
 }
+
+func TestGroveChildrenParseNodeFails(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	reply, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	replyFile.Buffer.Truncate(1)
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	// add node to fs, now should be discoverable
+	fs.files[replyFile.Name()] = replyFile
+
+	if children, err := g.Children(reply.ID()); err == nil {
+		t.Errorf("Expected error when parsing node file to be propagated upward, but Children() did not error")
+	} else if len(children) > 0 {
+		t.Errorf("Expected no child nodes for when parsing a node failed, found %d", len(children))
+	}
+}

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -543,7 +543,6 @@ func TestGroveRecent(t *testing.T) {
 
 		}
 	}
-	// TODO: check that they are sorted and are the right three nodes
 
 	// reset fakeFiles so they can be read again
 	resetAll := func() {
@@ -555,5 +554,42 @@ func TestGroveRecent(t *testing.T) {
 	}
 	resetAll()
 
-	// TODO: test other quantities and node types
+	if replies, err := g.Recent(fields.NodeTypeReply, 2); err != nil {
+		t.Errorf("Did not expect valid query for recent replies to err: %v", err)
+	} else if len(replies) != 2 {
+		t.Errorf("Expected %d nodes, got %d", 2, len(replies))
+	}
+
+	resetAll()
+
+	if ids, err := g.Recent(fields.NodeTypeIdentity, 2); err != nil {
+		t.Errorf("Did not expect valid query for recent identities to err: %v", err)
+	} else if len(ids) != 1 {
+		t.Errorf("Expected %d nodes, got %d", 1, len(ids))
+	} else {
+		asIdentity, isIdentity := ids[0].(*forest.Identity)
+		if !isIdentity {
+			t.Errorf("Recent() request for identities returned a different node type")
+		}
+		if !asIdentity.ID().Equals(identity.ID()) {
+			t.Errorf("Recent() didn't return the correct identity")
+		}
+	}
+
+	resetAll()
+
+	if communities, err := g.Recent(fields.NodeTypeCommunity, 2); err != nil {
+		t.Errorf("Did not expect valid query for recent identities to err: %v", err)
+	} else if len(communities) != 1 {
+		t.Errorf("Expected %d nodes, got %d", 1, len(communities))
+	} else {
+		asCommunity, isCommunity := communities[0].(*forest.Community)
+		if !isCommunity {
+			t.Errorf("Recent() request for communities returned a different node type")
+		}
+		if !asCommunity.ID().Equals(community.ID()) {
+			t.Errorf("Recent() didn't return the correct community")
+		}
+	}
+
 }

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -593,3 +593,24 @@ func TestGroveRecent(t *testing.T) {
 	}
 
 }
+
+func TestGroveRecentOpenNodeFails(t *testing.T) {
+	fs := newFakeFS()
+	fakeNodeBuilder := NewNodeBuilder(t)
+	_, replyFile := fakeNodeBuilder.newReplyFile("test content")
+	eReplyFile := NewErrFile(replyFile)
+	eReplyFile.error = os.ErrPermission
+	g, err := grove.NewWithFS(fs)
+	if err != nil {
+		t.Errorf("Failed constructing grove: %v", err)
+	}
+
+	// add node to fs, now should be discoverable
+	fs.files[eReplyFile.Name()] = eReplyFile
+
+	if replies, err := g.Recent(fields.NodeTypeReply, 5); err == nil {
+		t.Errorf("Expected permission error when reading node file to be propagated upward, but Recent() did not error")
+	} else if len(replies) > 0 {
+		t.Errorf("Expected no recent nodes for when reading a node failed, found %d", len(replies))
+	}
+}

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -85,6 +85,7 @@ type errFile struct {
 }
 
 var _ grove.File = &errFile{}
+var _ os.FileInfo = &errFile{}
 
 func NewErrFile(file grove.File) *errFile {
 	return &errFile{
@@ -94,6 +95,41 @@ func NewErrFile(file grove.File) *errFile {
 
 func (e *errFile) Name() string {
 	return e.wrappedFile.Name()
+}
+
+func (e *errFile) Size() int64 {
+	if fake, implements := e.wrappedFile.(os.FileInfo); implements {
+		return fake.Size()
+	}
+	return 0
+}
+
+func (e *errFile) Mode() os.FileMode {
+	if fake, implements := e.wrappedFile.(os.FileInfo); implements {
+		return fake.Mode()
+	}
+	return os.FileMode(0660)
+}
+
+func (e *errFile) ModTime() time.Time {
+	if fake, implements := e.wrappedFile.(os.FileInfo); implements {
+		return fake.ModTime()
+	}
+	return time.Now()
+}
+
+func (e *errFile) IsDir() bool {
+	if fake, implements := e.wrappedFile.(os.FileInfo); implements {
+		return fake.IsDir()
+	}
+	return false
+}
+
+func (e *errFile) Sys() interface{} {
+	if fake, implements := e.wrappedFile.(os.FileInfo); implements {
+		return fake.Sys()
+	}
+	return nil
 }
 
 func (e *errFile) Read(b []byte) (int, error) {

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -35,6 +35,10 @@ func (f *fakeFile) Close() error {
 	return nil
 }
 
+func (f *fakeFile) Readdir(n int) ([]os.FileInfo, error) {
+	return []os.FileInfo{}, nil
+}
+
 // fakeFS implements grove.FS, but is entirely in-memory.
 type fakeFS struct {
 	files map[string]*fakeFile

--- a/grove/grove_test.go
+++ b/grove/grove_test.go
@@ -39,9 +39,51 @@ func (f *fakeFile) Readdir(n int) ([]os.FileInfo, error) {
 	return []os.FileInfo{}, nil
 }
 
+// errFile implements the grove.File interface and wraps another grove.File.
+// If the errFile's error field is set to nil, it is a transparent wrapper
+// for the underlying File. If the field is set to a non-nil error value,
+// this will be returned from all operations that can return an error.
+type errFile struct {
+	error
+	wrappedFile grove.File
+}
+
+var _ grove.File = &errFile{}
+
+func NewErrFile(file grove.File) *errFile {
+	return &errFile{
+		wrappedFile: file,
+	}
+}
+
+func (e *errFile) Name() string {
+	return e.wrappedFile.Name()
+}
+
+func (e *errFile) Read(b []byte) (int, error) {
+	if e.error != nil {
+		return 0, e.error
+	}
+	return e.wrappedFile.Read(b)
+}
+
+func (e *errFile) Write(b []byte) (int, error) {
+	if e.error != nil {
+		return 0, e.error
+	}
+	return e.wrappedFile.Write(b)
+}
+
+func (e *errFile) Close() error {
+	if e.error != nil {
+		return e.error
+	}
+	return e.wrappedFile.Close()
+}
+
 // fakeFS implements grove.FS, but is entirely in-memory.
 type fakeFS struct {
-	files map[string]*fakeFile
+	files map[string]grove.File
 }
 
 var _ grove.FS = fakeFS{}
@@ -70,7 +112,7 @@ func (r fakeFS) OpenFile(path string, flag int, perm os.FileMode) (grove.File, e
 
 func newFakeFS() fakeFS {
 	return fakeFS{
-		make(map[string]*fakeFile),
+		make(map[string]grove.File),
 	}
 }
 


### PR DESCRIPTION
So this PR is bigger than normal, but that's for several reasons:

- some of the test infrastructure included here is already in several existing PRs
- these two methods required some common infrastructure (quite a lot actually), and I didn't want to duplicate that code in multiple PRs on top of the duplicated test infrastructure.
- this is the last chunk of code needed to finish the initial `Grove` type implementation. I'm human, tired, and the thought of separating this out into several PRs is really hard to bear right now. 